### PR TITLE
Replaced '.' with '<<' in documentation of '<|' function

### DIFF
--- a/src/Basics.elm
+++ b/src/Basics.elm
@@ -403,7 +403,7 @@ avoiding parenthesis. Consider the following code to create a text element:
 
 This can also be written as:
 
-        text . monospace <| toText "code"
+        text << monospace <| toText "code"
 -}
 (<|) : (a -> b) -> a -> b
 f <| x = f x


### PR DESCRIPTION
Spotted this when reading documentation on http://library.elm-lang.org/catalog/elm-lang-Elm/0.13/Basics#<|
