### PR TITLE
another small documentation fix

### DIFF
--- a/src/Random.elm
+++ b/src/Random.elm
@@ -164,7 +164,7 @@ pair (Generator genLeft) (Generator genRight) =
         ((left,right), seed'')
 
 
-{-| Create a list of random values using a generator function.
+{-| Create a list of random values.
 
     floatList : Generator (List Float)
     floatList =


### PR DESCRIPTION
The "using a generator function" part does not make sense to the user after it is not anymore exposed that a Generator is a function of type so-and-so. One could say something like "Create a list of random values using a provided generator for list elements." But the documentation for pair also just says "Create a pair of random values.", not "... using two provided generators for the components".
