### PR TITLE
Was a syntax error in the example for object3.

### DIFF
--- a/src/Json/Decode.elm
+++ b/src/Json/Decode.elm
@@ -127,7 +127,7 @@ object2 =
 {-| Use two different decoders on a JS value. This is nice for extracting
 multiple fields from an object.
 
-    type Task = { task : String, id : Int, completed : Bool }
+    type alias Task = { task : String, id : Int, completed : Bool }
 
     point : Decoder (Float,Float)
     point =


### PR DESCRIPTION
Missing the "alias" keyword in the example in the documentation.
