### PR TITLE
Fix error logging for non-browser environments.

### DIFF
--- a/src/Native/Runtime.js
+++ b/src/Native/Runtime.js
@@ -123,11 +123,11 @@ if (!Elm.fullscreen) {
                 checkPorts(elm);
             }
             catch (error) {
-                if (typeof document === 'undefined') {
-                    console.log(e.message);
-                    throw error;
+                if (typeof container.appendChild == 'undefined') {
+                    console.log(error.message);
+                } else {
+                    container.appendChild(errorNode(error.message));
                 }
-                container.appendChild(errorNode(error.message));
                 throw error;
             }
             inputs = filterDeadInputs(inputs);


### PR DESCRIPTION
Two things:
1. `e` was changed to `error` because `e` doesn't exist.
2. We check the existence of actual method `appendChild`, not a proxy (if `document` exists). Because it is possible that we are in an environment with a `document` but still initialized by `Elm.worker`, which gives `{}` for `container`.
