### PR TITLE
toString: don’t escape single quotes in strings and double quotes in char.

### DIFF
--- a/src/Native/Show.js
+++ b/src/Native/Show.js
@@ -22,10 +22,10 @@ Elm.Native.Show.make = function(elm) {
             return v + "";
         }
         else if ((v instanceof String) && v.isChar) {
-            return "'" + addSlashes(v) + "'";
+            return "'" + addSlashes(v, true) + "'";
         }
         else if (type === "string") {
-            return '"' + addSlashes(v) + '"';
+            return '"' + addSlashes(v, false) + '"';
         }
         else if (type === "object" && '_' in v && probablyPublic(v)) {
             var output = [];
@@ -103,15 +103,18 @@ Elm.Native.Show.make = function(elm) {
         return "<internal structure>";
     };
 
-    function addSlashes(str) {
-        return str.replace(/\\/g, '\\\\')
+    function addSlashes(str, isChar) {
+        var s = str.replace(/\\/g, '\\\\')
                   .replace(/\n/g, '\\n')
                   .replace(/\t/g, '\\t')
                   .replace(/\r/g, '\\r')
                   .replace(/\v/g, '\\v')
-                  .replace(/\0/g, '\\0')
-                  .replace(/\'/g, "\\'")
-                  .replace(/\"/g, '\\"');
+                  .replace(/\0/g, '\\0');
+        if (isChar) {
+            return s.replace(/\'/g, "\\'")
+        } else {
+            return s.replace(/\"/g, '\\"');
+        }
     }
 
     function probablyPublic(v) {

--- a/tests/Test/Basics.elm
+++ b/tests/Test/Basics.elm
@@ -14,8 +14,18 @@ tests =
             , test "clamp mid" <| assertEqual 15 (clamp 10 20 15)
             , test "clamp high" <| assertEqual 20 (clamp 10 20 25)
             ]
+        toStringTests = suite "toString Tests"
+            [ test "toString Int" <| assertEqual "42" (toString 42)
+            , test "toString Float" <| assertEqual "42.52" (toString 42.52)
+            , test "toString Char" <| assertEqual "'c'" (toString 'c')
+            , test "toString Char single quote" <| assertEqual "'\\''" (toString '\'')
+            , test "toString Char double quote" <| assertEqual "'\"'" (toString '"')
+            , test "toString String single quote" <| assertEqual "\"not 'escaped'\"" (toString "not 'escaped'")
+            , test "toString String double quote" <| assertEqual "\"are \\\"escaped\\\"\"" (toString "are \"escaped\"")
+            ]
 
     in
         suite "Basics"
             [ comparison
+            , toStringTests
             ]


### PR DESCRIPTION
I propose not escaping the `'` in strings and `"` in chars because otherwise you get outputs like this:
`(Err "could not convert string \'y\' to an Int")`
