### PR TITLE
Assign neutral colors a hue of 0° when converting to HSL

### DIFF
--- a/src/Color.elm
+++ b/src/Color.elm
@@ -187,13 +187,16 @@ rgbToHsl red green blue =
     c = cMax - cMin
 
     hue =
-      degrees 60 *
-        if cMax == r then
-          ((g - b) / c) `fmod` 6
-        else if cMax == g then
-          ((b - r) / c) + 2
-        else {- cMax == b -}
-          ((r - g) / c) + 4
+      if c == 0 then
+        0
+      else
+        degrees 60 *
+          if cMax == r then
+            ((g - b) / c) `fmod` 6
+          else if cMax == g then
+            ((b - r) / c) + 2
+          else {- cMax == b -}
+            ((r - g) / c) + 4
 
     lightness =
       (cMax + cMin) / 2


### PR DESCRIPTION
Converting a neutral color e.g. black (in RGB representation) to a HSL representation yields a hue value of `NaN` (because of calling `%` on `Infinity`.

``` Elm
import Color

hsl = Color.toHsl (Color.rgb 0 0 0)
-- == { hue = NaN, saturation = 0, lightness = 0, alpha = 1 }
```

This can be avoided by special casing a chroma of `0` and assigning it a hue of `0`.
