### PR TITLE
Fix Color.rgbToHsl function to not return NaN for certain cases.

### DIFF
--- a/src/Color.elm
+++ b/src/Color.elm
@@ -188,18 +188,22 @@ rgbToHsl red green blue =
 
     hue =
       degrees 60 *
-        if cMax == r then
+        if c == 0 then
+          0
+        else if cMax == r then
           ((g - b) / c) `fmod` 6
         else if cMax == g then
           ((b - r) / c) + 2
-        else {- cMax == b -}
+        else if cMax == b then
           ((r - g) / c) + 4
+        else
+          0
 
     lightness =
       (cMax + cMin) / 2
 
     saturation =
-      if lightness == 0 then
+      if c == 0 then
         0
       else
         c / (1 - abs (2 * lightness - 1))

--- a/tests/Test.elm
+++ b/tests/Test.elm
@@ -16,6 +16,7 @@ import Test.Result as Result
 import Test.Set as Set
 import Test.String as String
 import Test.Regex as Regex
+import Test.Color as Color
 
 tests : Test
 tests =
@@ -33,6 +34,7 @@ tests =
         , Set.tests
         , String.tests
         , Regex.tests
+        , Color.tests
         ]
 
 

--- a/tests/Test/Color.elm
+++ b/tests/Test/Color.elm
@@ -1,0 +1,25 @@
+module Test.Color exposing (tests)
+
+import Basics exposing (..)
+import Color
+import List
+
+import ElmTest exposing (..)
+
+hslToTuple : Color.Color -> (Float, Float, Float)
+hslToTuple color =
+  let
+    { hue, saturation, lightness } = Color.toHsl color
+  in
+    (hue, saturation, lightness)
+
+tests : Test
+tests = suite "Color"
+  [ suite "rgbaToHsl"
+    [ test "white" <| assertEqual (0,0,1) (hslToTuple Color.white)
+    , test "black" <| assertEqual (0,0,0) (hslToTuple Color.black)
+    , test "blue" <| assertEqual (degrees 240,1,0.5) (hslToTuple (Color.rgb 0 0 255))
+    , test "red" <| assertEqual (0,1,0.5) (hslToTuple (Color.rgb 255 0 0))
+    , test "green" <| assertEqual (degrees 120,1,0.5) (hslToTuple (Color.rgb 0 255 0))
+    ]
+  ]


### PR DESCRIPTION
The current implementation of `Color.rgbToHsl` (https://github.com/elm-lang/core/blob/master/src/Color.elm#L176-L208) is not correct and gives invalid results for some colors:
- white -> (NaN, NaN, 1)
- black -> (NaN, 0, 0)

Following the formulas in this website http://www.rapidtables.com/convert/color/rgb-to-hsl.htm this PR fixes this behavior.

Also added some tests for these and some other colors.
