### PR TITLE
Fixes Basics.truncate for values larger than 32 bit ints

### DIFF
--- a/src/Native/Basics.js
+++ b/src/Native/Basics.js
@@ -73,7 +73,7 @@ function isInfinite(n)
 
 function truncate(n)
 {
-	return n | 0;
+	return n < 0 ? Math.ceil(n) : Math.floor(n);
 }
 
 function degrees(d)


### PR DESCRIPTION
The current native JavaScript implementation uses the `n | 0` bit-wise operation to truncate the value. This is restricted by the definition of bit-wise operations. They are defined to operate on 32 bit signed integers.

In general, JavaScript allows 64 bit floating point numbers. With these, integers can be represented up to `2^53 - 1` aka [Number.MAX_SAFE_INTEGER](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). By using a bit-wise operation, the usable range of Int in Elm is restricted artificially.

The implementation is replaced here with `Math.ceil` and `Math.floor` depending on the sign. Testing in a REPL now successfully evaluates e.g. `truncate <| 2.45 * (2 ^ 33)`, which would have been impossible before.

Such a restriction is a) unnecessary and b) unexpected. I highly suggest removing it.