### PR TITLE
Add AnimationFrame package link and update docs for Time.every

### DIFF
--- a/src/Time.elm
+++ b/src/Time.elm
@@ -61,10 +61,12 @@ subscriptions work.
 
 [arch]: https://github.com/evancz/elm-architecture-tutorial/
 
-**Note:** this function is not for animation! You need to use something based
-on `requestAnimationFrame` to get smooth animations. This is based on
+**Note:** this function is not for animation! It is based on
 `setInterval` which is better for recurring tasks like “check on something
-every 30 seconds”.
+every 30 seconds”. For smooth animations you should use [AnimationFrame][animationframe] 
+which is based on `requestAnimationFrame`.
+
+[animationframe]: http://package.elm-lang.org/packages/elm-lang/animation-frame/latest
 -}
 every : Time -> (Time -> msg) -> Sub msg
 every interval tagger =


### PR DESCRIPTION
Updated the docs for Time.every, referring/linking to the AnimationFrame package in the note. Someone might interpret this as `requestAnimationFrame` not being available in Elm without a port (https://github.com/furrary/react-fiber-demo/pull/3#issuecomment-347727613).

_note: I wasn't able to test this as elm make docs didn't seem to work._