### PR TITLE
Clarify (==) Json.Encode.Value limitations

### DIFF
--- a/src/Basics.elm
+++ b/src/Basics.elm
@@ -318,9 +318,11 @@ same&rdquo; but detecting this in general is [undecidable][]. In a future
 release, the compiler will detect when `(==)` is used with problematic
 types and provide a helpful error message. This will require quite serious
 infrastructure work that makes sense to batch with another big project, so the
-stopgap is to crash as quickly as possible. Problematic types include functions
-and JavaScript values like `Json.Encode.Value` which could contain functions
-if passed through a port.
+stopgap is to crash as quickly as possible. Problematic types include functions,
+and JavaScript values such as `Json.Encode.Value`. JavaScript values could
+contain functions if passed through a port; even when they do not, two
+JavaScript values can appear equal even if one contains keys that the other
+does not.
 
 [undecidable]: https://en.wikipedia.org/wiki/Undecidable_problem
 -}


### PR DESCRIPTION
The documentation for (==) implied (to me) that (==) would work on
Json.Encode.Values that didn't include functions. This is not the case.
This change attempts to clarify this. It doesn't go into exact detail
about the failure cases (one order works, another doesn't), because it
seemed like this had to do with implementation details that are better
not relied on; instead, it attempts to steer the reader away for using
(==) on Json.Encode.Values at all.

See <https://discourse.elm-lang.org/t/json-encode-value-equality/898>
for discussion.