### PR TITLE
Removed duplicate function declaration. Error in Google Closure Compiler

### DIFF
--- a/src/Native/Json.js
+++ b/src/Native/Json.js
@@ -163,11 +163,6 @@ function badPrimitive(type, value)
 	return { tag: 'primitive', type: type, value: value };
 }
 
-function badIndex(index, nestedProblems)
-{
-	return { tag: 'index', index: index, rest: nestedProblems };
-}
-
 function badField(field, nestedProblems)
 {
 	return { tag: 'field', field: field, rest: nestedProblems };


### PR DESCRIPTION
This fix is commited on top of the 5.1.1 tag

[Google Closure Compiler](https://developers.google.com/closure/compiler/) complains about this:

```
ERROR - Duplicate let / const / class / function declaration in the same scope is not allowed.
function badIndex(index, nestedProblems)
         ^^^^^^^^
```

The function `badIndex` is declared twice in the `Native.Json` module.
This looks like a PR merge mistake so I just removed the duplicate declaration.