### PR TITLE
Fix optimized `compare` when first arg is Nil

### DIFF
--- a/src/Elm/Kernel/Utils.js
+++ b/src/Elm/Kernel/Utils.js
@@ -101,7 +101,7 @@ function _Utils_cmp(x, y, ord)
 	//*/
 
 	/**__PROD/
-	if (!x.$)
+	if (!x.hasOwnProperty('$'))
 	//*/
 	/**__DEBUG/
 	if (x.$[0] === '#')

--- a/src/Elm/Kernel/Utils.js
+++ b/src/Elm/Kernel/Utils.js
@@ -101,7 +101,7 @@ function _Utils_cmp(x, y, ord)
 	//*/
 
 	/**__PROD/
-	if (!x.hasOwnProperty('$'))
+	if (typeof x.$ === 'undefined'))
 	//*/
 	/**__DEBUG/
 	if (x.$[0] === '#')


### PR DESCRIPTION
Fix a "truthiness" bug in the PROD version of `_Utils_cmp`

[This line](https://github.com/elm/core/blob/master/src/Elm/Kernel/Utils.js#L104) wants to check if the first argument is a Tuple. In PROD mode it uses `if (!x.$)` to check for falsiness, since tuples have no `$` property in PROD mode.

Unfortunately `_List_Nil` can also be passed in here, which is represented as `{ $: 0 }`. When that happens, `x.$` _exists_, but since it is falsy it passes the condition and is misidentified as a tuple! The tuple-related code then runs even though the inputs are lists. This can produce incorrect results, such as in the SSCCE below.

This PR fixes it by using `hasOwnProperty` instead of a truthiness check.

(There are, of course, lots of ways to check for missing properties. Not sure what your preference is. I figured that checking the existence of a property should be more efficient than doing anything with its value. Dunno if that's right or not.)

```elm
module Main exposing (main)

import Browser
import Html exposing (Html, text)

main = Browser.sandbox
    { init = ()
    , view = view
    , update = \() () -> ()
    }

view : () -> Html msg
view () =
    if [] < [0] then
        text "Default compile shows this"
    else
        text "--optimize shows this"
```
