### PR TITLE
Spell hexadecimal correctly

### DIFF
--- a/src/Basics.elm
+++ b/src/Basics.elm
@@ -98,8 +98,8 @@ infix right 9 (>>) = composeR
     0
     42
     9000
-    0xFF   -- 255 in hexidecimal
-    0x000A --  10 in hexidecimal
+    0xFF   -- 255 in hexadecimal
+    0x000A --  10 in hexadecimal
 
 **Note:** `Int` math is well-defined in the range `-2^31` to `2^31 - 1`. Outside
 of that range, the behavior is determined by the compilation target. When

--- a/src/Char.elm
+++ b/src/Char.elm
@@ -181,7 +181,7 @@ isOctDigit char =
     code <= 0x37 && 0x30 <= code
 
 
-{-| Detect hexidecimal digits `0123456789abcdefABCDEF`
+{-| Detect hexadecimal digits `0123456789abcdefABCDEF`
 -}
 isHexDigit : Char -> Bool
 isHexDigit char =


### PR DESCRIPTION
See its Wiktionary [entry](https://en.wiktionary.org/w/index.php?oldid=49742097&title=hexadecimal).