### PR TITLE
Updated Documention: Task examples for Browser.Dom.focus were pointing to the wrong location

### DIFF
--- a/src/Task.elm
+++ b/src/Task.elm
@@ -38,16 +38,16 @@ import Result exposing (Result(..))
 {-| Here are some common tasks:
 
 - [`Time.now : Task x Posix`][now]
-- [`Browser.focus : String -> Task DomError ()`][focus]
+- [`Browser.Dom.focus : String -> Task Browser.Dom.Error ()`][focus]
 - [`Process.sleep : Float -> Task x ()`][sleep]
 
 [now]: /packages/elm/time/latest/Time#now
-[focus]: /packages/elm/browser/latest/Browser#focus
+[focus]: /packages/elm/browser/latest/Browser-Dom#focus
 [sleep]: /packages/elm/core/latest/Process#sleep
 
 In each case we have a `Task` that will resolve successfully with an `a` value
-or unsuccessfully with an `x` value. So `Browser.focus` we may fail with a
-`DomError` if the given ID does not exist. Whereas `Time.now` never fails so
+or unsuccessfully with an `x` value. So `Browser.Dom.focus` we may fail with a
+`Browser.Dom.Error` if the given ID does not exist. Whereas `Time.now` never fails so
 I cannot be more specific than `x`. No such value will ever exist! Instead it
 always succeeds with the current POSIX time.
 
@@ -288,16 +288,17 @@ perform toMessage task =
 So we could _attempt_ to focus on a certain DOM node like this:
 
     import Browser  -- elm install elm/browser
+    import Browser.Dom
     import Task
 
     type Msg
       = Click
       | Search String
-      | Focus (Result Browser.DomError ())
+      | Focus (Result Browser.Dom.Error ())
 
     focus : Cmd Msg
     focus =
-      Task.attempt Focus (Browser.focus "my-app-search-box")
+      Task.attempt Focus (Browser.Dom.focus "my-app-search-box")
 
 So the task is "focus on this DOM node" and we are turning it into the command
 "Hey Elm, attempt to focus on this DOM node and give me a `Msg` about whether


### PR DESCRIPTION
The Task examples that used `Browser.Dom.focus` pointed to the wrong location. They also used the wrong Error type so I updated all of these to point in the correct location and use the correct modules, functions, and types.