### PR TITLE
Improve overall iteration performance

### DIFF
--- a/src/Elm/Kernel/JsArray.js
+++ b/src/Elm/Kernel/JsArray.js
@@ -21,7 +21,7 @@ var _JsArray_initialize = F3(function(size, offset, func)
 {
     var result = new Array(size);
 
-    for (var i = 0; i < size; i++)
+    for (var i = 0; size - i; i++)
     {
         result[i] = func(offset + i);
     }
@@ -33,7 +33,7 @@ var _JsArray_initializeFromList = F2(function (max, ls)
 {
     var result = new Array(max);
 
-    for (var i = 0; i < max && ls.b; i++)
+    for (var i = 0; max - i && ls.b; i++)
     {
         result[i] = ls.a;
         ls = ls.b;
@@ -53,7 +53,7 @@ var _JsArray_unsafeSet = F3(function(index, value, array)
     var length = array.length;
     var result = new Array(length);
 
-    for (var i = 0; i < length; i++)
+    for (var i = 0; length - i; i++)
     {
         result[i] = array[i];
     }
@@ -67,7 +67,7 @@ var _JsArray_push = F2(function(value, array)
     var length = array.length;
     var result = new Array(length + 1);
 
-    for (var i = 0; i < length; i++)
+    for (var i = 0; length - i; i++)
     {
         result[i] = array[i];
     }
@@ -80,7 +80,7 @@ var _JsArray_foldl = F3(function(func, acc, array)
 {
     var length = array.length;
 
-    for (var i = 0; i < length; i++)
+    for (var i = 0; length - i; i++)
     {
         acc = A2(func, array[i], acc);
     }
@@ -90,7 +90,7 @@ var _JsArray_foldl = F3(function(func, acc, array)
 
 var _JsArray_foldr = F3(function(func, acc, array)
 {
-    for (var i = array.length - 1; i >= 0; i--)
+    for (var i = array.length; i--;)
     {
         acc = A2(func, array[i], acc);
     }
@@ -103,7 +103,7 @@ var _JsArray_map = F2(function(func, array)
     var length = array.length;
     var result = new Array(length);
 
-    for (var i = 0; i < length; i++)
+    for (var i = 0; length - i; i++)
     {
         result[i] = func(array[i]);
     }
@@ -116,7 +116,7 @@ var _JsArray_indexedMap = F3(function(func, offset, array)
     var length = array.length;
     var result = new Array(length);
 
-    for (var i = 0; i < length; i++)
+    for (var i = 0; length - i; i++)
     {
         result[i] = A2(func, offset + i, array[i]);
     }
@@ -142,12 +142,12 @@ var _JsArray_appendN = F3(function(n, dest, source)
     var size = destLen + itemsToCopy;
     var result = new Array(size);
 
-    for (var i = 0; i < destLen; i++)
+    for (var i = 0; destLen - i; i++)
     {
         result[i] = dest[i];
     }
 
-    for (var i = 0; i < itemsToCopy; i++)
+    for (var i = 0; itemsToCopy - i; i++)
     {
         result[i + destLen] = source[i];
     }

--- a/src/Elm/Kernel/String.js
+++ b/src/Elm/Kernel/String.js
@@ -38,18 +38,17 @@ var _String_map = F2(function(func, string)
 {
 	var len = string.length;
 	var array = new Array(len);
-	var i = 0;
-	while (i < len)
+	var i = len;
+	while (i--)
 	{
 		var word = string.charCodeAt(i);
-		if (0xD800 <= word && word <= 0xDBFF)
+		if (0xDC00 <= word && word <= 0xDFFF)
 		{
-			array[i] = func(__Utils_chr(string[i] + string[i+1]));
-			i += 2;
+			array[i] = func(_Utils_chr(string[i] + string[i-1]));
+			i--;
 			continue;
 		}
-		array[i] = func(__Utils_chr(string[i]));
-		i++;
+		array[i] = func(_Utils_chr(string[i]));
 	}
 	return array.join('');
 });

--- a/src/Elm/Kernel/String.js
+++ b/src/Elm/Kernel/String.js
@@ -44,7 +44,7 @@ var _String_map = F2(function(func, string)
 		var word = string.charCodeAt(i);
 		if (0xD800 <= word && word <= 0xDBFF)
 		{
-			array[i] = func(_Utils_chr(string[i] + string[i+1]));
+			array[i] = func(__Utils_chr(string[i] + string[i+1]));
 			i += 2;
 			continue;
 		}

--- a/src/Elm/Kernel/String.js
+++ b/src/Elm/Kernel/String.js
@@ -280,8 +280,9 @@ function _String_toInt(str)
 	var total = 0;
 	var code0 = str.charCodeAt(0);
 	var start = code0 == 0x2B /* + */ || code0 == 0x2D /* - */ ? 1 : 0;
+	var len = str.length;
 
-	for (var i = start; i < str.length; ++i)
+	for (var i = start; len - i; ++i)
 	{
 		var code = str.charCodeAt(i);
 		if (code < 0x30 || 0x39 < code)

--- a/src/Elm/Kernel/String.js
+++ b/src/Elm/Kernel/String.js
@@ -38,16 +38,18 @@ var _String_map = F2(function(func, string)
 {
 	var len = string.length;
 	var array = new Array(len);
-	var i = len;
-	while (i--)
+	var i = 0;
+	while (len-i)
 	{
 		var word = string.charCodeAt(i);
-		if (0xDC00 <= word && word <= 0xDFFF)
+		if (0xD800 <= word && word <= 0xDBFF)
 		{
-			array[i] = func(__Utils_chr(string[i] + string[--i]));
+			array[i] = func(_Utils_chr(string[i] + string[i+1]));
+			i += 2;
 			continue;
 		}
 		array[i] = func(__Utils_chr(string[i]));
+		i++;
 	}
 	return array.join('');
 });
@@ -80,19 +82,21 @@ function _String_reverse(str)
 {
 	var len = str.length;
 	var arr = new Array(len);
-	var i = len;
-	while (i--)
+	var i = 0;
+	while (len-i)
 	{
 		var word = str.charCodeAt(i);
-		if (0xDC00 <= word && word <= 0xDFFF)
+		if (0xD800 <= word && word <= 0xDBFF)
 		{
-			arr[len - i - 1] = str[i - 1];
-			i--;
-			arr[len - i - 1] = str[i + 1];
+			arr[len - i] = str[i + 1];
+			i++;
+			arr[len - i] = str[i - 1];
+			i++;
 		}
 		else
 		{
-			arr[len - i - 1] = str[i];
+			arr[len - i] = str[i];
+			i++;
 		}
 	}
 	return arr.join('');

--- a/src/Elm/Kernel/String.js
+++ b/src/Elm/Kernel/String.js
@@ -44,11 +44,11 @@ var _String_map = F2(function(func, string)
 		var word = string.charCodeAt(i);
 		if (0xDC00 <= word && word <= 0xDFFF)
 		{
-			array[i] = func(_Utils_chr(string[i] + string[i-1]));
+			array[i] = func(__Utils_chr(string[i] + string[i-1]));
 			i--;
 			continue;
 		}
-		array[i] = func(_Utils_chr(string[i]));
+		array[i] = func(__Utils_chr(string[i]));
 	}
 	return array.join('');
 });

--- a/src/Elm/Kernel/String.js
+++ b/src/Elm/Kernel/String.js
@@ -59,7 +59,7 @@ var _String_filter = F2(function(isGood, str)
 	var arr = [];
 	var len = str.length;
 	var i = 0;
-	while (i < len)
+	while (len-i)
 	{
 		var char = str[i];
 		var word = str.charCodeAt(i);
@@ -106,7 +106,7 @@ var _String_foldl = F3(function(func, state, string)
 {
 	var len = string.length;
 	var i = 0;
-	while (i < len)
+	while (len-i)
 	{
 		var char = string[i];
 		var word = string.charCodeAt(i);

--- a/src/Elm/Kernel/String.js
+++ b/src/Elm/Kernel/String.js
@@ -44,8 +44,7 @@ var _String_map = F2(function(func, string)
 		var word = string.charCodeAt(i);
 		if (0xDC00 <= word && word <= 0xDFFF)
 		{
-			array[i] = func(__Utils_chr(string[i] + string[i-1]));
-			i--;
+			array[i] = func(__Utils_chr(string[i] + string[--i]));
 			continue;
 		}
 		array[i] = func(__Utils_chr(string[i]));

--- a/src/Elm/Kernel/String.js
+++ b/src/Elm/Kernel/String.js
@@ -82,21 +82,19 @@ function _String_reverse(str)
 {
 	var len = str.length;
 	var arr = new Array(len);
-	var i = 0;
-	while (i < len)
+	var i = len;
+	while (i--)
 	{
 		var word = str.charCodeAt(i);
-		if (0xD800 <= word && word <= 0xDBFF)
+		if (0xDC00 <= word && word <= 0xDFFF)
 		{
-			arr[len - i] = str[i + 1];
-			i++;
-			arr[len - i] = str[i - 1];
-			i++;
+			arr[len - i - 1] = str[i - 1];
+			i--;
+			arr[len - i - 1] = str[i + 1];
 		}
 		else
 		{
-			arr[len - i] = str[i];
-			i++;
+			arr[len - i - 1] = str[i];
 		}
 	}
 	return arr.join('');


### PR DESCRIPTION
Multiple modules in core loop through list, arrays, and objects in various ways. Some can't be improved like the while cons, but there are a number of them that could be restructured to gain quite a bit of performance for not much, or any, file size increase.

A performance test bench detailed [here](https://web.archive.org/web/20141205235948/https://blogs.oracle.com/greimer/entry/best_way_to_code_a) shows many cases where a decrementing while loop with a simple conditional is the fastest looping structure.

```
var i=arr.length; while (i--) {}
```

I know this can't always be achieved given the functionality of the loop, but in the worst case we can ensure small improvements. For example, I've found various cases where a for-loop's length could be cached so it is not having to be calculated every iteration. It sounds small, but it even has better performance.

I'm planning to implement and test many of the areas I've found and report on the results for performance and also verifying functionality was not altered.