### PR TITLE
Added Debug.logTime function for easier performance debugging

### DIFF
--- a/src/Debug.elm
+++ b/src/Debug.elm
@@ -2,13 +2,14 @@ module Debug exposing
   ( toString
   , log
   , todo
+  , logTime
   )
 
 {-| This module can be useful while _developing_ an application. It is not
 available for use in packages or production.
 
 # Debugging
-@docs toString, log, todo
+@docs toString, log, todo, logTime
 -}
 
 
@@ -94,4 +95,33 @@ goes unhandled!
 todo : String -> a
 todo =
   Elm.Kernel.Debug.todo
+
+
+{-| Log the execution time of a function.
+
+This will help you track down performance issues by logging the execution
+time of any function to the console. Most browsers also displays the time in
+their [performance debugging] tools.
+The first argument is a label which will be displayed in the console. This helps
+when tracking multiple functions at the same time.
+
+This will call `fn` with `arg` and log the execution time in the console. The
+return value will be whatever `fn` returns.
+
+    logTime "name in console" fn arg
+
+If a function takes more than one argument you need to apply all but the last
+one, effectively creating a one argument function.
+
+    logTime "render header" (renderHeader arg1 arg2) arg3
+
+**Note:** This is not available with `elm make --optimize` or in packages. The
+idea is that `logTime` can be useful during development, but you would't want
+to clutter the console with this information in the resulting application.
+
+[performance debugging]: https://developers.google.com/web/tools/chrome-devtools/console/track-executions
+-}
+logTime : String -> (a -> b) -> a -> b
+logTime =
+  Elm.Kernel.Debug.logTime
 

--- a/src/Elm/Kernel/Debug.js
+++ b/src/Elm/Kernel/Debug.js
@@ -300,3 +300,19 @@ function _Debug_regionToString(region)
 	}
 	return 'on lines ' + region.__$start.__$line + ' through ' + region.__$end.__$line;
 }
+
+// LOG TIME
+
+var _Debug_logTime__PROD = F3(function(name, fn, arg)
+{
+	return fn(arg);
+});
+
+var _Debug_logTime__DEBUG = F3(function(name, fn, arg)
+{
+	console.time(name);
+	var returnValue = fn(arg);
+	console.timeEnd(name);
+
+	return returnValue;
+});


### PR DESCRIPTION
This lets you "tag" any function for easy performance debugging. More info in [this discourse thread](https://discourse.elm-lang.org/t/very-useful-function-when-optimizing-render/1517).

Wrap any function in your code:
![image](https://user-images.githubusercontent.com/8900986/49327243-66c9ce80-f55f-11e8-8528-8ebb0fa930b3.png)

This will log the execution time in the console:
![image](https://user-images.githubusercontent.com/8900986/49327232-2407f680-f55f-11e8-9b53-b7c9c9d18bf6.png)

It is also visible in the performance timeline:
![image](https://user-images.githubusercontent.com/8900986/49327259-9d074e00-f55f-11e8-800d-c70389549f46.png)
