### PR TITLE
Fix small error in Task docs

### DIFF
--- a/src/Task.elm
+++ b/src/Task.elm
@@ -293,7 +293,7 @@ So we could _attempt_ to focus on a certain DOM node like this:
     type Msg
       = Click
       | Search String
-      | Focus (Result Browser.DomError ())
+      | Focus (Result Browser.Dom.Error ())
 
     focus : Cmd Msg
     focus =


### PR DESCRIPTION
I was trying to set focus on an element and found some relevant docs; however, I noticed that there was a mistake/typo with a referenced type.