### PR TITLE
Improve performance of List.append

### DIFF
--- a/src/List.elm
+++ b/src/List.elm
@@ -363,14 +363,8 @@ product numbers =
 You can also use [the `(++)` operator](Basics#++) to append lists.
 -}
 append : List a -> List a -> List a
-append xs ys =
-  case ys of
-    [] ->
-      xs
-
-    _ ->
-      foldr cons ys xs
-
+append =
+    (++)
 
 {-| Concatenate a bunch of lists into a single list:
 


### PR DESCRIPTION
I did some [benchmarks](https://github.com/jhrcek/faster-list-concat) and it turns out that thanks to this improvement the implementation of `List.concat` about 2x (in Google Chrome) to 3x (in Firefox) faster than the current implementation.

