### PR TITLE
Improve run-tests.sh

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -39,7 +39,7 @@ echo "seeding framework for test dependencies ...";
 # '|| true' lets us ignore failures here and keep the script running.
 # useful when developing a fix for a bug that exists in the version of
 # elm/core hosted on package.elm-lang.org
-"${ELM_TEST}" tests/Main.elm > /dev/null || true;
+"${ELM_TEST}" tests/Main.elm --fuzz=1 > /dev/null || true;
 
 # clear out the copy of elm-core fetched by the above and replace it
 # with the local source code we want to actually test
@@ -51,6 +51,7 @@ CORE_GIT_DIR="$(dirname $PWD)"
 echo;
 echo "Linking $CORE_PACKAGE_DIR to $CORE_GIT_DIR"
 echo;
+
 rm -rf "$CORE_PACKAGE_DIR"
 ln -sv "$CORE_GIT_DIR" "$CORE_PACKAGE_DIR"
 rm -vf "${CORE_GIT_DIR}"/*.dat "${CORE_GIT_DIR}"/doc*.json
@@ -66,4 +67,4 @@ echo;
 echo "running tests ...";
 echo;
 
-"${ELM_TEST}" tests/Main.elm;
+"${ELM_TEST}" tests/Main.elm $@;


### PR DESCRIPTION
This reduces the time it takes to "seed" the test, by reducing fuzz tests to a minimum.

It also passes along the arguments to `elm-test`. So `run-tests.sh --watch` => `elm-test --watch`.