### PR TITLE
run-tests.sh: fix argument passing to use proper quoting

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -67,4 +67,4 @@ echo;
 echo "running tests ...";
 echo;
 
-"${ELM_TEST}" tests/Main.elm $@;
+"${ELM_TEST}" tests/Main.elm "$@";


### PR DESCRIPTION
so that arguments containing spaces aren't split up