### PR TITLE
Fixes runtime exception when comparing inequal lists with over 100 elements

### DIFF
--- a/src/Elm/Kernel/Utils.js
+++ b/src/Elm/Kernel/Utils.js
@@ -31,16 +31,16 @@ function _Utils_eqHelp(x, y, depth, stack)
 		return true;
 	}
 
-	if (depth > 100)
-	{
-		stack.push(_Utils_Tuple2(x,y));
-		return true;
-	}
-
 	if (typeof x !== 'object' || x === null || y === null)
 	{
 		typeof x === 'function' && __Debug_crash(5);
 		return false;
+	}
+
+	if (depth > 100)
+	{
+		stack.push(_Utils_Tuple2(x,y));
+		return true;
 	}
 
 	/**__DEBUG/

--- a/src/Elm/Kernel/Utils.js
+++ b/src/Elm/Kernel/Utils.js
@@ -26,14 +26,14 @@ function _Utils_eq(x, y)
 
 function _Utils_eqHelp(x, y, depth, stack)
 {
-	if (depth > 100)
+	if (x === y)
 	{
-		stack.push(_Utils_Tuple2(x,y));
 		return true;
 	}
 
-	if (x === y)
+	if (depth > 100)
 	{
+		stack.push(_Utils_Tuple2(x,y));
 		return true;
 	}
 

--- a/tests/tests/Test/Equality.elm
+++ b/tests/tests/Test/Equality.elm
@@ -1,9 +1,10 @@
 module Test.Equality exposing (tests)
 
 import Basics exposing (..)
+import Expect
+import Fuzz
 import Maybe exposing (..)
 import Test exposing (..)
-import Expect
 
 
 type Different
@@ -30,5 +31,14 @@ tests =
                 , test "ctor diff" <| \() -> Expect.equal True ({ field = Just 3 } /= { field = Nothing })
                 , test "ctor diff, special case" <| \() -> Expect.equal True ({ ctor = Just 3 } /= { ctor = Nothing })
                 ]
+
+        listTests =
+            describe "List equality"
+                [ fuzz2 (Fuzz.intRange 100 10000) (Fuzz.intRange 100 10000) "Simple comparison" <|
+                    \size1 size2 ->
+                        Expect.equal
+                            (size1 == size2)
+                            (List.range 0 size1 == List.range 0 size2)
+                ]
     in
-        describe "Equality Tests" [ diffTests, recordTests ]
+        describe "Equality Tests" [ diffTests, recordTests, listTests ]


### PR DESCRIPTION
This has the same solution as #1018, but uses fuzz testing instead of unit tests. This PR is also not conflated with upgrading the testing code for 0.19.