### PR TITLE
Faster String.map, String.filter and String.reverse

### DIFF
--- a/src/Elm/Kernel/String.js
+++ b/src/Elm/Kernel/String.js
@@ -80,26 +80,20 @@ var _String_filter = F2(function(isGood, str)
 
 function _String_reverse(str)
 {
-	var len = str.length;
-	var arr = new Array(len);
-	var i = 0;
-	while (i < len)
+	var result = '';
+	var i = str.length;
+	while (i--)
 	{
+		var char = str[i];
 		var word = str.charCodeAt(i);
-		if (0xD800 <= word && word <= 0xDBFF)
+		if (0xDC00 <= word && word <= 0xDFFF)
 		{
-			arr[len - i] = str[i + 1];
-			i++;
-			arr[len - i] = str[i - 1];
-			i++;
+			i--;
+			char = str[i] + char;
 		}
-		else
-		{
-			arr[len - i] = str[i];
-			i++;
-		}
+		result += char;
 	}
-	return arr.join('');
+	return result;
 }
 
 var _String_foldl = F3(function(func, state, string)

--- a/src/Elm/Kernel/String.js
+++ b/src/Elm/Kernel/String.js
@@ -37,26 +37,26 @@ function _String_length(str)
 var _String_map = F2(function(func, string)
 {
 	var len = string.length;
-	var array = new Array(len);
+	var result = '';
 	var i = 0;
 	while (i < len)
 	{
 		var word = string.charCodeAt(i);
 		if (0xD800 <= word && word <= 0xDBFF)
 		{
-			array[i] = func(__Utils_chr(string[i] + string[i+1]));
+			result += func(__Utils_chr(string[i] + string[i+1]));
 			i += 2;
 			continue;
 		}
-		array[i] = func(__Utils_chr(string[i]));
+		result += func(__Utils_chr(string[i]));
 		i++;
 	}
-	return array.join('');
+	return result;
 });
 
 var _String_filter = F2(function(isGood, str)
 {
-	var arr = [];
+	var result = '';
 	var len = str.length;
 	var i = 0;
 	while (i < len)
@@ -72,10 +72,10 @@ var _String_filter = F2(function(isGood, str)
 
 		if (isGood(__Utils_chr(char)))
 		{
-			arr.push(char);
+			result += char;
 		}
 	}
-	return arr.join('');
+	return result;
 });
 
 function _String_reverse(str)


### PR DESCRIPTION
Turns out browsers are pretty fast at string concatination. By eliminating the temporary array in String.map, String.filter and string.reverse, we can get some pretty nice performance improvements.

For Chrome:
Map: 22% increase
Filter: 44% increase
Reverse: 59% incrase

I've also verified that there are performance improvements in Firefox and Safari as well :)