### PR TITLE
Use native log10 for logBase with base of 10

### DIFF
--- a/src/Basics.elm
+++ b/src/Basics.elm
@@ -614,9 +614,12 @@ sqrt =
 -}
 logBase : Float -> Float -> Float
 logBase base number =
-  fdiv
-    (Elm.Kernel.Basics.log number)
-    (Elm.Kernel.Basics.log base)
+  if base == 10 then
+    Elm.Kernel.Basics.log10 number
+  else
+    fdiv
+      (Elm.Kernel.Basics.log number)
+      (Elm.Kernel.Basics.log base)
 
 
 {-| An approximation of e.

--- a/src/Elm/Kernel/Basics.js
+++ b/src/Elm/Kernel/Basics.js
@@ -53,6 +53,7 @@ var _Basics_floor = Math.floor;
 var _Basics_round = Math.round;
 var _Basics_sqrt = Math.sqrt;
 var _Basics_log = Math.log;
+var _Basics_log10 = Math.log10;
 var _Basics_isNaN = isNaN;
 
 

--- a/tests/tests/Test/Basics.elm
+++ b/tests/tests/Test/Basics.elm
@@ -134,6 +134,7 @@ tests =
                 , test "abs -25" <| \() -> Expect.equal 25 (abs -25)
                 , test "abs 76" <| \() -> Expect.equal 76 (abs 76)
                 , test "logBase 10 100" <| \() -> Expect.equal 2 (logBase 10 100)
+                , test "logBase 10 1000" <| \() -> Expect.equal 3 (logBase 10 1000)
                 , test "logBase 2 256" <| \() -> Expect.equal 8 (logBase 2 256)
                 , test "e" <| \() -> Expect.lessThan 0.01 (abs (2.72 - e))
                 ]


### PR DESCRIPTION
Current logBase implementation is not precise enough. For example: `logBase 10 100 == 2` but `logBase 10 1000 /= 3`.

The proposed change is to use a separate native Javascript log10 function for logs with base 10.

This would close #1048 