### PR TITLE
Fixes String.uncons returning Nothing on null byte

### DIFF
--- a/src/Elm/Kernel/String.js
+++ b/src/Elm/Kernel/String.js
@@ -15,7 +15,7 @@ var _String_cons = F2(function(chr, str)
 function _String_uncons(string)
 {
 	var word = string.charCodeAt(0);
-	return word
+	return !isNaN(word)
 		? __Maybe_Just(
 			0xD800 <= word && word <= 0xDBFF
 				? __Utils_Tuple2(__Utils_chr(string[0] + string[1]), string.slice(2))


### PR DESCRIPTION
`String.uncons "\u{0000}"` should equal `Just ( '\u{0000}', "" )`, but it equals `Nothing`.

`string.chartCodeAt(0)` returns `0` on a null byte and `NaN` on an empty string. Instead of coercing to boolean in the ternary, it's better to use `isNaN`.

This would fix #1035 