### PR TITLE
test: fix test runner for elm 0.19.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: elm
 
+elm:
+  - latest
+
+elm_test: latest
+
+elm_format: latest
+
 script:
   - bash tests/run-tests.sh

--- a/tests/elm.json
+++ b/tests/elm.json
@@ -1,7 +1,7 @@
 {
     "type": "application",
     "source-directories": [],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
             "elm/browser": "1.0.1",

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -44,8 +44,8 @@ echo "seeding framework for test dependencies ...";
 # clear out the copy of elm-core fetched by the above and replace it
 # with the local source code we want to actually test
 
-VERSION_DIR="$(ls ${ELM_HOME}/0.19.0/package/elm/core/)"
-CORE_PACKAGE_DIR="${ELM_HOME}/0.19.0/package/elm/core/$VERSION_DIR"
+VERSION_DIR="$(ls ${ELM_HOME}/0.19.1/packages/elm/core/)"
+CORE_PACKAGE_DIR="${ELM_HOME}/0.19.1/packages/elm/core/$VERSION_DIR"
 CORE_GIT_DIR="$(dirname $PWD)"
 
 echo;


### PR DESCRIPTION
This commit contains a few minor changes to the bash script used to run tests.

This means that CI runs using elm 0.19.1 can still show as green.

cc: @jerith666 and @Skinney