### PR TITLE
fix missing scope declaration on variable

### DIFF
--- a/src/Elm/Kernel/Platform.js
+++ b/src/Elm/Kernel/Platform.js
@@ -44,7 +44,7 @@ function _Platform_initialize(flagDecoder, args, init, update, subscriptions, st
 
 	function sendToApp(msg, viewMetadata)
 	{
-		result = A2(update, msg, model);
+		var result = A2(update, msg, model);
 		stepper(model = result.a, viewMetadata);
 		_Platform_enqueueEffects(managers, result.b, subscriptions(model));
 	}


### PR DESCRIPTION
Add missing scope declaration on `result` variable.

The underlying issue caused by the missing scope declaration is that some tasks are not performed during synchronous event processing (more details on the listed issues below).

This fixes the following issues:
* elm/virtual-dom#146
* elm/virtual-dom#152