### PR TITLE
Add String.split example

### DIFF
--- a/src/String.elm
+++ b/src/String.elm
@@ -184,6 +184,7 @@ concat strings =
 
     split "," "cat,dog,cow"        == ["cat","dog","cow"]
     split "/" "home/evan/Desktop/" == ["home","evan","Desktop", ""]
+    split "," ""                   == [""]
 
 -}
 split : String -> String -> List String


### PR DESCRIPTION
to show that it always returns at least one list item even if the string is empty