### PR TITLE
Make the imports in the prelude consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ import Tuple
 
 import Debug
 
-import Platform exposing ( Program )
-import Platform.Cmd as Cmd exposing ( Cmd )
-import Platform.Sub as Sub exposing ( Sub )
+import Platform exposing (Program)
+import Platform.Cmd as Cmd exposing (Cmd)
+import Platform.Sub as Sub exposing (Sub)
 ```
 
 The intention is to include things that are both extremely useful and very unlikely to overlap with anything that anyone will ever write in a library. By keeping the set of default imports relatively small, it also becomes easier to use whatever version of `map` suits your fancy. Finally, it makes it easier to figure out where the heck a function is coming from.


### PR DESCRIPTION
Some had spaces around the imported type, some don't.
This makes the imports consistent, by removing the spaces in the ones
that had them.