### PR TITLE
emphasize the limitations of Process.spawn

### DIFF
--- a/src/Process.elm
+++ b/src/Process.elm
@@ -13,8 +13,10 @@ module Process exposing
 ## Future Plans
 
 Right now, this library is pretty sparse. For example, there is no public API
-for processes to communicate with each other. This is a really important
-ability, but it is also something that is extraordinarily easy to get wrong!
+for processes to communicate with each other. (To be clear, this means that 
+spawned process can't return a message to the main processs, even upon 
+completion.) This is a really important ability, but it is also something that is
+extraordinarily easy to get wrong!
 
 I think the trend will be towards an Erlang style of concurrency, where every
 process has an “event queue” that anyone can send messages to. I currently
@@ -76,8 +78,8 @@ there.
       |> Task.andThen (\_ -> spawn task2)
 
 **Note:** This creates a relatively restricted kind of `Process` because it
-cannot receive any messages. More flexibility for user-defined processes will
-come in a later release!
+cannot receive any messages, *nor send any back to the main process*. More
+utility for user-defined processes will come in a later release!
 -}
 spawn : Task x a -> Task y Id
 spawn =
@@ -98,7 +100,7 @@ sleep =
 {-| Sometimes you `spawn` a process, but later decide it would be a waste to
 have it keep running and doing stuff. The `kill` function will force a process
 to bail on whatever task it is running. So if there is an HTTP request in
-flight, it will also abort the request.
+flight, it will also abort the request. 
 -}
 kill : Id -> Task x ()
 kill =

--- a/src/Process.elm
+++ b/src/Process.elm
@@ -13,8 +13,8 @@ module Process exposing
 ## Future Plans
 
 Right now, this library is pretty sparse. For example, there is no public API
-for processes to communicate with each other. (To be clear, this means that 
-spawned process can't return a message to the main processs, even upon 
+for processes to communicate with each other. (To be clear, this means that a
+spawned process can't ever return a message to the main processs, even upon 
 completion.) This is a really important ability, but it is also something that is
 extraordinarily easy to get wrong!
 


### PR DESCRIPTION
Having read the `Process` module docs and noted the lack of inter-process communication API, I still managed to spend a day writing code on the incorrect assumption that I could return a message to the main process from a spawned process, say, upon completion of the spawned process. Woe unto my labor of the day!

It turns out that at least a couple of others shared my misconception on slack, and I think the docs could be much clearer on this crucial limitation. 

The bare existence of `Process.spawn` and `Process.sleep` implies that they are useful, when, as far as I can tell, the only thing Process.spawn is useful for is running delayed, cancelable, fire-and-forget network operations. Similarly, `Process.sleep` is unlikely to be interesting on the main thread (unless you're ok blocking user interaction), and so its existence implies that interesting things can be done in a subprocess. In this case, I use the word "interesting" to mean "consequential to the state of the main process", but since subprocesses can't even return a message to main, I find them mostly uninteresting. 

To be short, this module feels like a stub. I grant that the "future plans" section is technically unambiguous about its limitations, but the surrounding context makes it easy to overlook this grain of clarity. 

This PR has some draft modifications of the docs that attempt to address the issue; happy to revise given feedback!