### PR TITLE
correctly compare bytes in ==

### DIFF
--- a/src/Elm/Kernel/Utils.js
+++ b/src/Elm/Kernel/Utils.js
@@ -63,6 +63,20 @@ function _Utils_eqHelp(x, y, depth, stack)
 		y = __Dict_toList(y);
 	}
 	//*/
+	
+	if (typeof DataView === "function" && x instanceof DataView) {
+		let length = x.byteLength;
+		
+		if (y.byteLength !== length) {
+			return false;
+		}
+
+		for (let i = 0; i < length; ++i) {
+			if (x.getUint8(i) !== y.getUint8(i)) {
+				return false;
+			}
+		}
+	}
 
 	for (var key in x)
 	{


### PR DESCRIPTION
`Bytes` equality requires a special case in `_Utils_eqHelp`. This PR adds that special case.

Fixes https://github.com/elm/bytes/issues/15