### PR TITLE
replace refernce to `%` with `modBy`

### DIFF
--- a/hints/11.md
+++ b/hints/11.md
@@ -9,7 +9,7 @@ If you let their support team know about this error, please give them a link to 
 
 ## Info for Developers
 
-Your application is calling `n % 0` at some point, causing a crash. This may be happening in your code or in a dependency.
+Your application is calling `modBy 0 n` at some point, causing a crash. This may be happening in your code or in a dependency.
 
 You can get more detailed information about when this happens if you can reproduce this error in dev mode.
 


### PR DESCRIPTION
I just ran into a runtime error caused by calling `Basics.modBy` with the arguments in the wrong order, leading to a value of 0 as the first argument. The error had a link to [the 1.0.0 version of the page i edited](https://github.com/elm/core/blob/1.0.0/hints/11.md). My understanding is that `%` has been removed from the language, in favor of `remainderBy` and `modBy`, so, given that the old version of the page would still be around for old versions of elm, changing this to reference `modBy` seems better. 

As mentioned in [this issue comment](https://github.com/elm/core/issues/1034#issuecomment-503159937), `remainderBy 0 n` currently returns `NaN` instead of leading to this page, so I didn't mention it.