### PR TITLE
Fix typo on Task.attempt document (Browser.Dom.Error)

### DIFF
--- a/src/Task.elm
+++ b/src/Task.elm
@@ -293,7 +293,7 @@ So we could _attempt_ to focus on a certain DOM node like this:
     type Msg
       = Click
       | Search String
-      | Focus (Result Browser.DomError ())
+      | Focus (Result Browser.Dom.Error ())
 
     focus : Cmd Msg
     focus =


### PR DESCRIPTION
Fix typo on `Task.attempt` document by changing `Browser.DomError` (not exist) to `Browser.Dom.Error`.

ref: https://package.elm-lang.org/packages/elm/browser/latest/Browser-Dom#Error