### PR TITLE
Add forgotten test to the test suite

### DIFF
--- a/tests/tests/Test/Basics.elm
+++ b/tests/tests/Test/Basics.elm
@@ -209,6 +209,7 @@ tests =
             , trigTests
             , basicMathTests
             , booleanTests
+            , conversionTests
             , miscTests
             , higherOrderTests
             ]


### PR DESCRIPTION
I found a suite of tests that were created but not included in the tests to run.

Note: I have not been able to re-run tests, as tests break for a different reason (already on `master`). I tried running with the latest version of `elm` and `elm-test` for 0.19.0 and for 0.19.1 without success.