### PR TITLE
Fix #1107 (optimized version)

### DIFF
--- a/src/Basics.elm
+++ b/src/Basics.elm
@@ -10,7 +10,7 @@ module Basics exposing
   , pi, cos, sin, tan, acos, asin, atan, atan2
   , degrees, radians, turns
   , toPolar, fromPolar
-  , isNaN, isInfinite
+  , isNaN, isInfinite, isPositiveInfinity, isNegativeInfinity
   , identity, always, (<|), (|>), (<<), (>>), Never, never
   )
 
@@ -52,7 +52,7 @@ things.
 @docs toPolar, fromPolar
 
 # Floating Point Checks
-@docs isNaN, isInfinite
+@docs isNaN, isInfinite, isPositiveInfinity, isNegativeInfinity
 
 # Function Helpers
 @docs identity, always, (<|), (|>), (<<), (>>), Never, never
@@ -827,6 +827,27 @@ isInfinite : Float -> Bool
 isInfinite =
   Elm.Kernel.Basics.isInfinite
 
+
+{-| Determine whether a float is equal to positive infinity.
+
+    isPositiveInfinity 1      == False
+    isPositiveInfinity (1/0)  == True
+    isPositiveInfinity -(1/0) == False
+-}
+isPositiveInfinity : Float -> Bool
+isPositiveInfinity =
+  Elm.Kernel.Basics.isPositiveInfinity
+
+
+{-| Determine whether a float is equal to positive infinity.
+
+    isNegativeInfinity 1      == False
+    isNegativeInfinity (1/0)  == False
+    isNegativeInfinity -(1/0) == True
+-}
+isNegativeInfinity : Float -> Bool
+isNegativeInfinity =
+  Elm.Kernel.Basics.isNegativeInfinity
 
 
 -- FUNCTION HELPERS

--- a/src/Elm/Kernel/Basics.js
+++ b/src/Elm/Kernel/Basics.js
@@ -47,6 +47,8 @@ var _Basics_atan2 = F2(Math.atan2);
 function _Basics_toFloat(x) { return x; }
 function _Basics_truncate(n) { return n | 0; }
 function _Basics_isInfinite(n) { return n === Infinity || n === -Infinity; }
+function _Basics_isPositiveInfinity(n) { return n === Infinity; }
+function _Basics_isNegativeInfinity(n) { return n === -Infinity; }
 
 var _Basics_ceiling = Math.ceil;
 var _Basics_floor = Math.floor;

--- a/src/List.elm
+++ b/src/List.elm
@@ -62,7 +62,7 @@ singleton value =
 -}
 repeat : Int -> a -> List a
 repeat n value =
-  if isInfinite n then
+  if isPositiveInfinity n then
     []
   
   else

--- a/src/List.elm
+++ b/src/List.elm
@@ -62,7 +62,11 @@ singleton value =
 -}
 repeat : Int -> a -> List a
 repeat n value =
-  repeatHelp [] n value
+  if isInfinite n then
+    []
+  
+  else
+    repeatHelp [] n value
 
 
 repeatHelp : List a -> Int -> a -> List a


### PR DESCRIPTION
See #1107, this is a more optimized version than just an `isInfinite` check, because it specifically checks only for positive infinity (the edge case here).

This adds two new `Kernel.Basics` JS functions (accessible via the associated `Basics` Elm functions):
`isPositiveInfinity` and `isNegativeInfinity`. These are useful for more than just this fix as well. 