### PR TITLE
Fix links to modules inside Debug

### DIFF
--- a/src/Debug.elm
+++ b/src/Debug.elm
@@ -88,7 +88,7 @@ idea is that a `todo` can be useful during development, but uncatchable runtime
 exceptions should not appear in the resulting applications.
 
 **Note:** For the equivalent of try/catch error handling in Elm, use modules
-like [`Maybe`](#Maybe) and [`Result`](#Result) which guarantee that no error
+like [`Maybe`](Maybe) and [`Result`](Result) which guarantee that no error
 goes unhandled!
 -}
 todo : String -> a


### PR DESCRIPTION
Hi :wave: 

I noticed that some links in this file were not leading to the expected location.

PS: I noticed this through an `elm-review` rule to be published soon :)