### PR TITLE
List.cons function available to the List module users

### DIFF
--- a/src/List.elm
+++ b/src/List.elm
@@ -1,5 +1,5 @@
 module List exposing
-  ( singleton, repeat, range, (::)
+  ( singleton, repeat, range, (::), cons
   , map, indexedMap, foldl, foldr, filter, filterMap
   , length, reverse, member, all, any, maximum, minimum, sum, product
   , append, concat, concatMap, intersperse, map2, map3, map4, map5


### PR DESCRIPTION
Because in Elm everything is simple and intuitive in a certain way, List.cons should be part of the functions available to the users besides the `(::)` function.
It happens in some parts of  the language standard libraries. For example, I can construct a tuple by using the literal form `(x, y)` or by calling the function `Tuple.pair x y` and both ways are OK and does not decrease the quality of the user code when using one or another.