### PR TITLE
Correct multiple spelling mistakes

### DIFF
--- a/src/Array.elm
+++ b/src/Array.elm
@@ -52,7 +52,7 @@ import Tuple
 
 
 {-| The array in this module is implemented as a tree with a high branching
-factor (number of elements at each level). In comparision, the `Dict` has
+factor (number of elements at each level). In comparison, the `Dict` has
 a branching factor of 2 (left or right).
 
 The higher the branching factor, the more elements are stored at each level.
@@ -86,7 +86,7 @@ any given level of the tree, we need to shift (or move) the correct amount of
 bits so that those bits are at the front. We can then perform a bitwise and to
 read which of the 32 branches to take.
 
-The `shiftStep` specifices how many bits are required to represent the branching
+The `shiftStep` specifies how many bits are required to represent the branching
 factor.
 -}
 shiftStep : Int

--- a/src/Elm/JsArray.elm
+++ b/src/Elm/JsArray.elm
@@ -69,7 +69,7 @@ length =
     Elm.Kernel.JsArray.length
 
 
-{-| Initialize an array. `initalize n offset fn` creates an array of length `n`
+{-| Initialize an array. `initialize n offset fn` creates an array of length `n`
 with the element at index `i` initialized to the result of `(f (i + offset))`.
 
 The offset parameter is there so one can avoid creating a closure for this use

--- a/src/String.elm
+++ b/src/String.elm
@@ -86,7 +86,7 @@ characters with different widths.
 
 [u]: https://en.wikipedia.org/wiki/Unicode
 
-**Note:** JavaScript lets you use double quotes and single quotes interchangably.
+**Note:** JavaScript lets you use double quotes and single quotes interchangeably.
 This is not true in Elm. You must use double quotes for a `String`, and you must
 use single quotes for a [`Char`](Char#Char).
 -}


### PR DESCRIPTION
Corrected
```
comparision → comparison
specifices → specifies
initalize → initialize
interchangably → interchangeably
```