### PR TITLE
Remove ANSI handling inside Debug.log implementation

### DIFF
--- a/src/Elm/Kernel/Debug.js
+++ b/src/Elm/Kernel/Debug.js
@@ -52,7 +52,6 @@ function _Debug_toString__DEBUG(value)
 
 function _Debug_toStringHelper(value)
 {
-	var ansi = false;
 	if (typeof value === 'function')
 	{
 		return '<function>';

--- a/src/Elm/Kernel/Debug.js
+++ b/src/Elm/Kernel/Debug.js
@@ -75,7 +75,7 @@ function _Debug_toStringHelper(value)
 
 	if (typeof value === 'string')
 	{
-		return _Debug_stringColor(ansi, '"' + _Debug_addSlashes(value, false) + '"');
+		return '"' + _Debug_addSlashes(value, false) + '"';
 	}
 
 	if (typeof value === 'object' && '$' in value)
@@ -143,7 +143,7 @@ function _Debug_toStringHelper(value)
 
 	if (typeof DataView === 'function' && value instanceof DataView)
 	{
-		return _Debug_stringColor(ansi, '<' + value.byteLength + ' bytes>');
+		return '<' + value.byteLength + ' bytes>';
 	}
 
 	if (typeof File !== 'undefined' && value instanceof File)
@@ -187,11 +187,6 @@ function _Debug_addSlashes(str, isChar)
 	{
 		return s.replace(/\"/g, '\\"');
 	}
-}
-
-function _Debug_stringColor(ansi, string)
-{
-	return ansi ? '\x1b[93m' + string + '\x1b[0m' : string;
 }
 
 function _Debug_toHexDigit(n)

--- a/src/Elm/Kernel/Debug.js
+++ b/src/Elm/Kernel/Debug.js
@@ -70,7 +70,7 @@ function _Debug_toStringHelper(value)
 
 	if (value instanceof String)
 	{
-		return _Debug_charColor(ansi, "'" + _Debug_addSlashes(value, true) + "'");
+		return "'" + _Debug_addSlashes(value, true) + "'";
 	}
 
 	if (typeof value === 'string')
@@ -192,11 +192,6 @@ function _Debug_addSlashes(str, isChar)
 function _Debug_stringColor(ansi, string)
 {
 	return ansi ? '\x1b[93m' + string + '\x1b[0m' : string;
-}
-
-function _Debug_charColor(ansi, string)
-{
-	return ansi ? '\x1b[92m' + string + '\x1b[0m' : string;
 }
 
 function _Debug_toHexDigit(n)

--- a/src/Elm/Kernel/Debug.js
+++ b/src/Elm/Kernel/Debug.js
@@ -60,7 +60,7 @@ function _Debug_toStringHelper(value)
 
 	if (typeof value === 'boolean')
 	{
-		return _Debug_ctorColor(ansi, value ? 'True' : 'False');
+		return value ? 'True' : 'False';
 	}
 
 	if (typeof value === 'number')
@@ -100,22 +100,19 @@ function _Debug_toStringHelper(value)
 
 		if (tag === 'Set_elm_builtin')
 		{
-			return _Debug_ctorColor(ansi, 'Set')
-				+ '.fromList '
+			return 'Set.fromList '
 				+ _Debug_toStringHelper(__Set_toList(value));
 		}
 
 		if (tag === 'RBNode_elm_builtin' || tag === 'RBEmpty_elm_builtin')
 		{
-			return _Debug_ctorColor(ansi, 'Dict')
-				+ '.fromList '
+			return 'Dict.fromList '
 				+ _Debug_toStringHelper(__Dict_toList(value));
 		}
 
 		if (tag === 'Array_elm_builtin')
 		{
-			return _Debug_ctorColor(ansi, 'Array')
-				+ '.fromList '
+			return 'Array.fromList '
 				+ _Debug_toStringHelper(__Array_toList(value));
 		}
 
@@ -141,7 +138,7 @@ function _Debug_toStringHelper(value)
 			var parenless = c0 === '{' || c0 === '(' || c0 === '[' || c0 === '<' || c0 === '"' || str.indexOf(' ') < 0;
 			output += ' ' + (parenless ? str : '(' + str + ')');
 		}
-		return _Debug_ctorColor(ansi, tag) + output;
+		return tag + output;
 	}
 
 	if (typeof DataView === 'function' && value instanceof DataView)
@@ -190,11 +187,6 @@ function _Debug_addSlashes(str, isChar)
 	{
 		return s.replace(/\"/g, '\\"');
 	}
-}
-
-function _Debug_ctorColor(ansi, string)
-{
-	return ansi ? '\x1b[96m' + string + '\x1b[0m' : string;
 }
 
 function _Debug_numberColor(ansi, string)

--- a/src/Elm/Kernel/Debug.js
+++ b/src/Elm/Kernel/Debug.js
@@ -47,11 +47,12 @@ function _Debug_toString__PROD(value)
 
 function _Debug_toString__DEBUG(value)
 {
-	return _Debug_toStringHelper(false, value);
+	return _Debug_toStringHelper(value);
 }
 
-function _Debug_toStringHelper(ansi, value)
+function _Debug_toStringHelper(value)
 {
+	var ansi = false;
 	if (typeof value === 'function')
 	{
 		return _Debug_internalColor(ansi, '<function>');
@@ -92,7 +93,7 @@ function _Debug_toStringHelper(ansi, value)
 			for (var k in value)
 			{
 				if (k === '$') continue;
-				output.push(_Debug_toStringHelper(ansi, value[k]));
+				output.push(_Debug_toStringHelper(value[k]));
 			}
 			return '(' + output.join(',') + ')';
 		}
@@ -101,32 +102,32 @@ function _Debug_toStringHelper(ansi, value)
 		{
 			return _Debug_ctorColor(ansi, 'Set')
 				+ _Debug_fadeColor(ansi, '.fromList') + ' '
-				+ _Debug_toStringHelper(ansi, __Set_toList(value));
+				+ _Debug_toStringHelper(__Set_toList(value));
 		}
 
 		if (tag === 'RBNode_elm_builtin' || tag === 'RBEmpty_elm_builtin')
 		{
 			return _Debug_ctorColor(ansi, 'Dict')
 				+ _Debug_fadeColor(ansi, '.fromList') + ' '
-				+ _Debug_toStringHelper(ansi, __Dict_toList(value));
+				+ _Debug_toStringHelper(__Dict_toList(value));
 		}
 
 		if (tag === 'Array_elm_builtin')
 		{
 			return _Debug_ctorColor(ansi, 'Array')
 				+ _Debug_fadeColor(ansi, '.fromList') + ' '
-				+ _Debug_toStringHelper(ansi, __Array_toList(value));
+				+ _Debug_toStringHelper(__Array_toList(value));
 		}
 
 		if (tag === '::' || tag === '[]')
 		{
 			var output = '[';
 
-			value.b && (output += _Debug_toStringHelper(ansi, value.a), value = value.b)
+			value.b && (output += _Debug_toStringHelper(value.a), value = value.b)
 
 			for (; value.b; value = value.b) // WHILE_CONS
 			{
-				output += ',' + _Debug_toStringHelper(ansi, value.a);
+				output += ',' + _Debug_toStringHelper(value.a);
 			}
 			return output + ']';
 		}
@@ -135,7 +136,7 @@ function _Debug_toStringHelper(ansi, value)
 		for (var i in value)
 		{
 			if (i === '$') continue;
-			var str = _Debug_toStringHelper(ansi, value[i]);
+			var str = _Debug_toStringHelper(value[i]);
 			var c0 = str[0];
 			var parenless = c0 === '{' || c0 === '(' || c0 === '[' || c0 === '<' || c0 === '"' || str.indexOf(' ') < 0;
 			output += ' ' + (parenless ? str : '(' + str + ')');
@@ -159,7 +160,7 @@ function _Debug_toStringHelper(ansi, value)
 		for (var key in value)
 		{
 			var field = key[0] === '_' ? key.slice(1) : key;
-			output.push(_Debug_fadeColor(ansi, field) + ' = ' + _Debug_toStringHelper(ansi, value[key]));
+			output.push(_Debug_fadeColor(ansi, field) + ' = ' + _Debug_toStringHelper(value[key]));
 		}
 		if (output.length === 0)
 		{

--- a/src/Elm/Kernel/Debug.js
+++ b/src/Elm/Kernel/Debug.js
@@ -65,7 +65,7 @@ function _Debug_toStringHelper(value)
 
 	if (typeof value === 'number')
 	{
-		return _Debug_numberColor(ansi, value + '');
+		return value + '';
 	}
 
 	if (value instanceof String)
@@ -187,11 +187,6 @@ function _Debug_addSlashes(str, isChar)
 	{
 		return s.replace(/\"/g, '\\"');
 	}
-}
-
-function _Debug_numberColor(ansi, string)
-{
-	return ansi ? '\x1b[95m' + string + '\x1b[0m' : string;
 }
 
 function _Debug_stringColor(ansi, string)

--- a/src/Elm/Kernel/Debug.js
+++ b/src/Elm/Kernel/Debug.js
@@ -101,21 +101,21 @@ function _Debug_toStringHelper(value)
 		if (tag === 'Set_elm_builtin')
 		{
 			return _Debug_ctorColor(ansi, 'Set')
-				+ _Debug_fadeColor(ansi, '.fromList') + ' '
+				+ '.fromList '
 				+ _Debug_toStringHelper(__Set_toList(value));
 		}
 
 		if (tag === 'RBNode_elm_builtin' || tag === 'RBEmpty_elm_builtin')
 		{
 			return _Debug_ctorColor(ansi, 'Dict')
-				+ _Debug_fadeColor(ansi, '.fromList') + ' '
+				+ '.fromList '
 				+ _Debug_toStringHelper(__Dict_toList(value));
 		}
 
 		if (tag === 'Array_elm_builtin')
 		{
 			return _Debug_ctorColor(ansi, 'Array')
-				+ _Debug_fadeColor(ansi, '.fromList') + ' '
+				+ '.fromList '
 				+ _Debug_toStringHelper(__Array_toList(value));
 		}
 
@@ -160,7 +160,7 @@ function _Debug_toStringHelper(value)
 		for (var key in value)
 		{
 			var field = key[0] === '_' ? key.slice(1) : key;
-			output.push(_Debug_fadeColor(ansi, field) + ' = ' + _Debug_toStringHelper(value[key]));
+			output.push(field + ' = ' + _Debug_toStringHelper(value[key]));
 		}
 		if (output.length === 0)
 		{
@@ -210,11 +210,6 @@ function _Debug_stringColor(ansi, string)
 function _Debug_charColor(ansi, string)
 {
 	return ansi ? '\x1b[92m' + string + '\x1b[0m' : string;
-}
-
-function _Debug_fadeColor(ansi, string)
-{
-	return ansi ? '\x1b[37m' + string + '\x1b[0m' : string;
 }
 
 function _Debug_toHexDigit(n)

--- a/src/Elm/Kernel/Debug.js
+++ b/src/Elm/Kernel/Debug.js
@@ -188,11 +188,6 @@ function _Debug_addSlashes(str, isChar)
 	}
 }
 
-function _Debug_toHexDigit(n)
-{
-	return String.fromCharCode(n < 10 ? 48 + n : 55 + n);
-}
-
 
 // CRASH
 

--- a/src/Elm/Kernel/Debug.js
+++ b/src/Elm/Kernel/Debug.js
@@ -47,10 +47,10 @@ function _Debug_toString__PROD(value)
 
 function _Debug_toString__DEBUG(value)
 {
-	return _Debug_toAnsiString(false, value);
+	return _Debug_toStringHelper(false, value);
 }
 
-function _Debug_toAnsiString(ansi, value)
+function _Debug_toStringHelper(ansi, value)
 {
 	if (typeof value === 'function')
 	{
@@ -92,7 +92,7 @@ function _Debug_toAnsiString(ansi, value)
 			for (var k in value)
 			{
 				if (k === '$') continue;
-				output.push(_Debug_toAnsiString(ansi, value[k]));
+				output.push(_Debug_toStringHelper(ansi, value[k]));
 			}
 			return '(' + output.join(',') + ')';
 		}
@@ -101,32 +101,32 @@ function _Debug_toAnsiString(ansi, value)
 		{
 			return _Debug_ctorColor(ansi, 'Set')
 				+ _Debug_fadeColor(ansi, '.fromList') + ' '
-				+ _Debug_toAnsiString(ansi, __Set_toList(value));
+				+ _Debug_toStringHelper(ansi, __Set_toList(value));
 		}
 
 		if (tag === 'RBNode_elm_builtin' || tag === 'RBEmpty_elm_builtin')
 		{
 			return _Debug_ctorColor(ansi, 'Dict')
 				+ _Debug_fadeColor(ansi, '.fromList') + ' '
-				+ _Debug_toAnsiString(ansi, __Dict_toList(value));
+				+ _Debug_toStringHelper(ansi, __Dict_toList(value));
 		}
 
 		if (tag === 'Array_elm_builtin')
 		{
 			return _Debug_ctorColor(ansi, 'Array')
 				+ _Debug_fadeColor(ansi, '.fromList') + ' '
-				+ _Debug_toAnsiString(ansi, __Array_toList(value));
+				+ _Debug_toStringHelper(ansi, __Array_toList(value));
 		}
 
 		if (tag === '::' || tag === '[]')
 		{
 			var output = '[';
 
-			value.b && (output += _Debug_toAnsiString(ansi, value.a), value = value.b)
+			value.b && (output += _Debug_toStringHelper(ansi, value.a), value = value.b)
 
 			for (; value.b; value = value.b) // WHILE_CONS
 			{
-				output += ',' + _Debug_toAnsiString(ansi, value.a);
+				output += ',' + _Debug_toStringHelper(ansi, value.a);
 			}
 			return output + ']';
 		}
@@ -135,7 +135,7 @@ function _Debug_toAnsiString(ansi, value)
 		for (var i in value)
 		{
 			if (i === '$') continue;
-			var str = _Debug_toAnsiString(ansi, value[i]);
+			var str = _Debug_toStringHelper(ansi, value[i]);
 			var c0 = str[0];
 			var parenless = c0 === '{' || c0 === '(' || c0 === '[' || c0 === '<' || c0 === '"' || str.indexOf(' ') < 0;
 			output += ' ' + (parenless ? str : '(' + str + ')');
@@ -159,7 +159,7 @@ function _Debug_toAnsiString(ansi, value)
 		for (var key in value)
 		{
 			var field = key[0] === '_' ? key.slice(1) : key;
-			output.push(_Debug_fadeColor(ansi, field) + ' = ' + _Debug_toAnsiString(ansi, value[key]));
+			output.push(_Debug_fadeColor(ansi, field) + ' = ' + _Debug_toStringHelper(ansi, value[key]));
 		}
 		if (output.length === 0)
 		{

--- a/src/Elm/Kernel/Debug.js
+++ b/src/Elm/Kernel/Debug.js
@@ -55,7 +55,7 @@ function _Debug_toStringHelper(value)
 	var ansi = false;
 	if (typeof value === 'function')
 	{
-		return _Debug_internalColor(ansi, '<function>');
+		return '<function>';
 	}
 
 	if (typeof value === 'boolean')
@@ -84,7 +84,7 @@ function _Debug_toStringHelper(value)
 
 		if (typeof tag === 'number')
 		{
-			return _Debug_internalColor(ansi, '<internals>');
+			return '<internals>;
 		}
 
 		if (tag[0] === '#')
@@ -151,7 +151,7 @@ function _Debug_toStringHelper(value)
 
 	if (typeof File !== 'undefined' && value instanceof File)
 	{
-		return _Debug_internalColor(ansi, '<' + value.name + '>');
+		return '<' + value.name + '>';
 	}
 
 	if (typeof value === 'object')
@@ -169,7 +169,7 @@ function _Debug_toStringHelper(value)
 		return '{ ' + output.join(', ') + ' }';
 	}
 
-	return _Debug_internalColor(ansi, '<internals>');
+	return '<internals>';
 }
 
 function _Debug_addSlashes(str, isChar)
@@ -215,11 +215,6 @@ function _Debug_charColor(ansi, string)
 function _Debug_fadeColor(ansi, string)
 {
 	return ansi ? '\x1b[37m' + string + '\x1b[0m' : string;
-}
-
-function _Debug_internalColor(ansi, string)
-{
-	return ansi ? '\x1b[36m' + string + '\x1b[0m' : string;
 }
 
 function _Debug_toHexDigit(n)


### PR DESCRIPTION
I noticed that `Debug.toString` calls `_Debug_toAnsiString(false, value)`, where `false` corresponds the `anis` parameter, which determines whether the printed value should be ANSI colored or not.

I have looked for other places where `_Debug_toAnsiString` is used in projects from either `elm` and `elm-explorations` organizations, and could not find any. Therefore, my assumption is that the `ansi` parameter is not used, and that it can therefore be removed. I **may** be missing something here though.

The proposed changes here are removing the `ansi` parameter from the `_Debug_toAnsiString` function, and then also removing and simplifying the places where the parameter was used.

There was also `_Debug_toHexDigit` that was not used (I could not find a reference to it in any of the aforementioned organizations).

The pull request can be removed commit by commit if you so like.