### PR TITLE
Specify permissions in workflows

### DIFF
--- a/.github/workflows/set-issue-expectations.yml
+++ b/.github/workflows/set-issue-expectations.yml
@@ -6,6 +6,8 @@ jobs:
   comment-on-issue:
     name: Comment On Issue
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: actions/github@v1.0.0
         env:

--- a/.github/workflows/set-pull-expectations.yml
+++ b/.github/workflows/set-pull-expectations.yml
@@ -7,6 +7,8 @@ jobs:
   comment-on-pull:
     name: Comment On Pull
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/github-script@v3
         with:


### PR DESCRIPTION
Forked repositories may not grant write permissions by default

There are two good approaches to handling workflows in forks:
1. Make the workflow check to see if it is in a fork and then have it not run. This is a good practice if your workflow is expensive or doesn't otherwise make sense to run in forks
2. Make sure your workflow has enough permissions to function in forks. An organization can be [configured to default to readonly workflow tokens](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#configuring-the-default-github_token-permissions) -- These two workflows do not behave properly in such repositories. Here's an [example of one of the workflows failing under these conditions](https://github.com/check-spelling/elm-core/actions/runs/2770358798) and with this [change applied](https://github.com/check-spelling/elm-core/actions/runs/2770382172). I didn't take the effort to create an issue with the default workflow (and my default branch does not have the workflow), but you can see that with the workflow fixed, [comments for new issues work](https://github.com/check-spelling/elm-core/actions/runs/2770415783).

Deciding whether to apply this change should probably be done as a set, as such, I'm not splitting these two changes into distinct PRs. Although you technically could apply them individually.

(Fwiw, the warnings they make are valuable, especially the one that explains how this repository wants its PRs, which is why I'm favoring the workflow running in forks instead of having it not run at all...)