### PR TITLE
src/Elm/Kernel/Utils.js handles Json.Encode.Value object values.

### DIFF
--- a/src/Elm/Kernel/Utils.js
+++ b/src/Elm/Kernel/Utils.js
@@ -37,6 +37,14 @@ function _Utils_eqHelp(x, y, depth, stack)
 		return false;
 	}
 
+        // Handle Json.Encode.Value
+        if (x.$ === 0) {
+                if (! (y.$ === 0)) {
+                        return false;
+                } else {
+                        return x.a == y.a
+                }
+
 	if (depth > 100)
 	{
 		stack.push(_Utils_Tuple2(x,y));


### PR DESCRIPTION
I have an application that stores the `Json.Encode.Value` from which its objects are decoded. When comparing two of these, one encoded raw from the wire, and one encoded from a saved version, `_Utils_eqHelp` crashes, because the wire version has fields that are missing in the decoded version. This pull request fixes that, by noticing that it has a `Value` in its hand, and using `==` right then, instead of descending recursively.

There's an Ellie example for this crash at https://ellie-app.com/kHr9dynry86a1