### PR TITLE
Fix `String.foldr` bug that causes infinite loop

### DIFF
--- a/src/Elm/Kernel/String.js
+++ b/src/Elm/Kernel/String.js
@@ -124,7 +124,7 @@ var _String_foldl = F3(function(func, state, string)
 var _String_foldr = F3(function(func, state, string)
 {
 	var i = string.length;
-	while (i--)
+	while (i-- > 0)
 	{
 		var char = string[i];
 		var word = string.charCodeAt(i);
@@ -190,7 +190,7 @@ function _String_toLower(str)
 var _String_any = F2(function(isGood, string)
 {
 	var i = string.length;
-	while (i--)
+	while (i-- > 0)
 	{
 		var char = string[i];
 		var word = string.charCodeAt(i);
@@ -210,7 +210,7 @@ var _String_any = F2(function(isGood, string)
 var _String_all = F2(function(isGood, string)
 {
 	var i = string.length;
-	while (i--)
+	while (i-- > 0)
 	{
 		var char = string[i];
 		var word = string.charCodeAt(i);


### PR DESCRIPTION
`String.all`, `String.any`, and functions using `String.foldr` have a bug that can cause infinite loop under certain conditions.

# SSCCE

```elm
-- `String.toList` is implemented with `String.foldr`
String.right 1 "foobar😈" |> String.toList
--> (causes infinite loop)
```

```elm
-- The following code, which determines whether the last character of a string is a space, is not uncommon:
String.right 1 "foobar😈" |> String.any (\c -> c == ' ')
--> (causes infinite loop)
```

```elm
String.right 1 "foobar😈" |> String.all (\c -> c /= ' ')
--> (causes infinite loop)
```

# Cause of the bug

Functions such as `foldr` do not expect that only part of a surrogate pair is given as an argument.

```js
var _String_foldr = F3(function(func, state, string)
{
	var i = string.length;
	while (i--)
	{
		var char = string[i];
		var word = string.charCodeAt(i);
		if (0xDC00 <= word && word <= 0xDFFF)
		{
			// This is harmful.
			i--;
			char = string[i] + char;
		}
		state = A2(func, __Utils_chr(char), state);
	}
	return state;
});
```

Hence, `i` in the above code jumps over `0` and becomes a negative value, resulting in an infinite loop.
