### PR TITLE
Task docs: fix a typo in the example for Task.attempt

### DIFF
--- a/src/Task.elm
+++ b/src/Task.elm
@@ -293,7 +293,7 @@ So we could _attempt_ to focus on a certain DOM node like this:
     type Msg
       = Click
       | Search String
-      | Focus (Result Browser.DomError ())
+      | Focus (Result Browser.Dom.Error ())
 
     focus : Cmd Msg
     focus =


### PR DESCRIPTION
It looks like there was just a missing `.` character.