### PR TITLE
Make foldr example code match commented return

### DIFF
--- a/src/Dict.elm
+++ b/src/Dict.elm
@@ -510,11 +510,11 @@ map func dict =
 
     import Dict exposing (Dict)
 
-    getAges : Dict String User -> List String
+    getAges : Dict String User -> List Int
     getAges users =
       Dict.foldl addAge [] users
 
-    addAge : String -> User -> List String -> List String
+    addAge : String -> User -> List Int -> List Int
     addAge _ user ages =
       user.age :: ages
 
@@ -534,11 +534,11 @@ foldl func acc dict =
 
     import Dict exposing (Dict)
 
-    getAges : Dict String User -> List String
+    getAges : Dict String User -> List Int
     getAges users =
       Dict.foldr addAge [] users
 
-    addAge : String -> User -> List String -> List String
+    addAge : String -> User -> List Int -> List Int
     addAge _ user ages =
       user.age :: ages
 


### PR DESCRIPTION
Addresses #1151 

This PR changes the commented code for [foldr](https://package.elm-lang.org/packages/elm/core/latest/Dict#foldr) and [foldl](https://package.elm-lang.org/packages/elm/core/latest/Dict#foldl) to match the intended example return value.